### PR TITLE
Add a closeButtonOnly option to modal

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -59,6 +59,12 @@ define(function(require) {
         closeable = false;
         break;
 
+      // Add option to only allow the close button to close the modal.
+      case "closeButtonOnly":
+        $el.prepend($closeLink);
+        closeable = false;
+        break;
+
       default:
         $el.prepend($closeLink);
         closeable = true;


### PR DESCRIPTION
Adds an option to the Modal to only allow the close button to close the modal. This way we can create modals that won't close when the user clicks on the overlay.

@DFurnes your :thought_balloon: 's ?
